### PR TITLE
Simple aggregation

### DIFF
--- a/cladecombiner/__init__.py
+++ b/cladecombiner/__init__.py
@@ -1,3 +1,7 @@
+from .aggregator import (
+    BasicPhylogeneticAggregator as BasicPhylogeneticAggregator,
+)
+from .aggregator import FixedAggregator as FixedAggregator
 from .nomenclature import PangoSc2Nomenclature as PangoSc2Nomenclature
 from .taxon import Taxon as Taxon
 from .taxon_utils import read_taxa as read_taxa

--- a/cladecombiner/aggregator.py
+++ b/cladecombiner/aggregator.py
@@ -86,7 +86,6 @@ class Aggregator(ABC):
         In the interim, self.messy_map is populated with the results of aggregation.
         """
         while self.stack:
-            print(f"++ Iterating, len(self.stack) = {str(len(self.stack))} ++")
             taxa_in = self.next_taxa()
             step = self.next_agg_step(taxa_in)
             self._valid_agg_step(step)
@@ -306,12 +305,6 @@ class BasicPhylogeneticAggregator(BoilerplateAggregator):
         else:
             self._cached_target = self.stack[-1]
             self._cached_taxa = [self._cached_target]
-            print(
-                "++++ Mapping otherwise unmapped taxon "
-                + str(self._cached_target)
-                + " to "
-                + str(self._cached_target)
-            )
         return self._cached_taxa
 
     def _valid_mapping(self):

--- a/cladecombiner/aggregator.py
+++ b/cladecombiner/aggregator.py
@@ -1,0 +1,184 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, MutableSequence
+from copy import copy
+from dataclasses import dataclass
+
+from .taxon import Taxon
+
+
+@dataclass
+class TaxonMapping:
+    """
+    Class for tracking proposed step in aggregation process
+    """
+
+    map: dict[Taxon, Taxon]
+    "from : to dictionary of the mapping"
+    done: dict[Taxon, bool]
+    "to : add_to_stack dictionary tracking if the aggregated taxon should be added back to the stack"
+
+
+class Aggregator(ABC):
+    """ """
+
+    @property
+    @abstractmethod
+    def input_taxa(self) -> Iterable[Taxon]:
+        """
+        The taxa which are to be aggregated.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def messy_map(self) -> dict[Taxon, Taxon]:
+        """
+        A record of the entire history of aggregation of all taxa.
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def stack(self) -> MutableSequence[Taxon]:
+        """
+        Taxa that still need to be aggregated.
+        """
+        pass
+
+    def aggregate(self):
+        """
+        Perform aggregation. When done, results may be collected with self.map().
+
+        In the interim, self.messy_map is populated with the results of aggregation.
+        """
+        while self.stack:
+            taxa_in = self.next_taxa()
+            step = self.next_agg_step(taxa_in)
+            self.check_agg_step(step)
+            self.resolve_agg_step(step)
+
+    def check_agg_step(self, mapping: TaxonMapping):
+        """
+        Check that this proposed merge move is acceptable
+        """
+        assert all(key in self.stack for key in mapping.map)
+
+    @abstractmethod
+    def next_taxa(self) -> Iterable[Taxon]:
+        """
+        Find the next taxon or taxa to merge.
+        """
+        pass
+
+    @abstractmethod
+    def next_agg_step(self, taxa: Iterable[Taxon]) -> TaxonMapping:
+        """
+        Find the next available step in the aggregation process for these taxa.
+        """
+        pass
+
+    def map(self):
+        """
+        Create clean {Taxon from : Taxon to} aggregation dictionary.
+        """
+        if len(self.stack) > 0:
+            self.aggregate()
+        taxon_map = {}
+        for taxon_from in self.input_taxa:
+            taxon_to = taxon_from
+            while taxon_to in self.messy_map.keys():
+                if taxon_to == self.messy_map[taxon_to]:
+                    # Self-mappings are possible
+                    break
+                taxon_to = self.messy_map[taxon_to]
+            taxon_map[taxon_from] = taxon_to
+        return taxon_map
+
+    def resolve_agg_step(self, mapping: TaxonMapping):
+        for k, v in mapping.map.items():
+            self.messy_map[k] = v
+            self.stack.remove(k)
+
+        for k, v in mapping.done.items():
+            if not v:
+                self.stack.append(k)
+
+
+class BoilerplateAggregator(Aggregator):
+    """
+    A mostly-instantiated Aggregator. Descendants need only implement next_agg_step() and next_taxa()
+    """
+
+    def __init__(
+        self,
+        in_taxa: Iterable[Taxon],
+    ):
+        self._input_taxa = in_taxa
+        self._last_target = Taxon("", False)
+        self._stack = list(copy(self._input_taxa))
+        self._messy_map = {}
+
+    @property
+    def input_taxa(self):
+        return self._input_taxa
+
+    @property
+    def messy_map(self) -> dict[Taxon, Taxon]:
+        return self._messy_map
+
+    @property
+    def stack(self) -> MutableSequence[Taxon]:
+        return self._stack
+
+
+class FixedAggregator(BoilerplateAggregator):
+    def __init__(self, names_to_aggregate: Iterable[str], map: dict[str, str]):
+        super().__init__(
+            in_taxa=[Taxon(nm, False) for nm in names_to_aggregate],
+        )
+        self.fixed_map = map
+
+    def next_agg_step(self, taxa: Iterable[Taxon]) -> TaxonMapping:
+        map = {}
+        done = {}
+        for taxon_from in taxa:
+            taxon_to = Taxon(self.fixed_map[taxon_from.name], False)
+            print("++++++ Mapping " + str(taxon_from) + " to " + str(taxon_to))
+            map[taxon_from] = taxon_to
+            done[taxon_to] = True
+
+        return TaxonMapping(map, done)
+
+    def next_taxa(self) -> Iterable[Taxon]:
+        return [self.stack[0]]
+
+
+# class FixedAggregator(Aggregator):
+
+#     def __init__(self, taxa_in: Iterable[str], map: dict[str, str]):
+#         self.fixed_map = map
+#         self._input_taxa = [Taxon(taxon, False) for taxon in taxa_in]
+#         self._last_target = Taxon("", False)
+#         self._stack = self._input_taxa
+#         self._map = {}
+#         self._messy_map = {}
+
+#     @property
+#     def input_taxa(self):
+#         return self._input_taxa
+
+#     @property
+#     def last_target(self):
+#         return self._last_target
+
+#     @property
+#     def stack(self):
+#         return self._stack
+
+#     @property
+#     def map(self):
+#         return self._map
+
+#     @property
+#     def messy_map(self):
+#         return self._messy_map

--- a/cladecombiner/ordered_taxon.py
+++ b/cladecombiner/ordered_taxon.py
@@ -8,7 +8,9 @@ from .taxonomy_scheme import TreelikeTaxonomyScheme
 @total_ordering
 class OrderedTaxon(Taxon):
     """
-    A Taxon equipped with a TreelikeTaxonomyScheme which we can sort.
+    A Taxon equipped with a TreelikeTaxonomyScheme which can be sorted.
+
+    For the purposes of comparison, "A < B" means "A is contained within B (but is not B)."
     """
 
     def __init__(

--- a/cladecombiner/ordered_taxon.py
+++ b/cladecombiner/ordered_taxon.py
@@ -1,0 +1,40 @@
+from functools import total_ordering
+from typing import Any
+
+from .taxon import Taxon
+from .taxonomy_scheme import TreelikeTaxonomyScheme
+
+
+@total_ordering
+class OrderedTaxon(Taxon):
+    """
+    A Taxon equipped with a TreelikeTaxonomyScheme which we can sort.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        is_tip: bool,
+        taxonomy_scheme: TreelikeTaxonomyScheme,
+        data: Any = None,
+    ):
+        super().__init__(name, is_tip, data)
+        self.taxonomy_scheme = taxonomy_scheme
+
+    @classmethod
+    def from_taxon(cls, taxon: Taxon, taxonomy_scheme: TreelikeTaxonomyScheme):
+        return cls(taxon.name, taxon.tip, taxonomy_scheme, taxon.data)
+
+    def to_taxon(self):
+        return Taxon(self.name, self.tip, self.data)
+
+    def __lt__(self, other):
+        assert (
+            hasattr(other, "taxonomy_scheme")
+            and self.taxonomy_scheme is other.taxonomy_scheme
+        )
+        if self == other:
+            return False
+        if self.taxonomy_scheme.contains(other, self):
+            return True
+        return False

--- a/cladecombiner/taxon.py
+++ b/cladecombiner/taxon.py
@@ -3,7 +3,7 @@ from typing import Any
 
 class Taxon:
     """
-    Representation of taxonomic units
+    Representation of taxonomic units.
     """
 
     def __init__(self, name: str, is_tip: bool, data: Any = None):

--- a/cladecombiner/taxon_utils.py
+++ b/cladecombiner/taxon_utils.py
@@ -9,9 +9,9 @@ from .taxonomy_scheme import TaxonomyScheme
 
 def read_taxa(
     fp: str,
-    is_tip: bool | Sequence[bool],
-    nomenclature: Optional[Nomenclature],
-    taxonomy_scheme: Optional[TaxonomyScheme],
+    is_tip: bool | Sequence[bool] = True,
+    nomenclature: Optional[Nomenclature] = None,
+    taxonomy_scheme: Optional[TaxonomyScheme] = None,
 ) -> Sequence[Taxon]:
     """
     Reads in taxa as a list of Taxon objects.
@@ -36,6 +36,11 @@ def read_taxa(
     Sequence[Taxon]
         Container of the taxa as Taxon objects.
     """
+    if nomenclature is not None:
+        assert isinstance(nomenclature, Nomenclature)
+
+    if taxonomy_scheme is not None:
+        assert isinstance(nomenclature, TaxonomyScheme)
 
     ext = path.splitext(fp)[1]
     taxa = []

--- a/cladecombiner/taxonomy_scheme.py
+++ b/cladecombiner/taxonomy_scheme.py
@@ -13,7 +13,6 @@ class TaxonomyScheme(ABC):
     Allows hybridization-induced multiple ancestry.
     """
 
-    @abstractmethod
     def ancestors(self, taxon: Taxon) -> Collection[Taxon]:
         """
         All taxa which are between this taxon and the root (including the root).

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -57,7 +57,72 @@ def test_no_drop_no_overlap(pango_with_toy_alias):
         "FLYING.123.123": "FLYING.123",
         "FLYING.123.7": "FLYING.123",
     }
-    print("+++++++++++++++++++++++++++++++++++++++++")
-    print(agg.map())
-    print("+++++++++++++++++++++++++++++++++++++++++")
+    assert agg.map() == expected
+
+
+def test_drop_other(pango_with_toy_alias):
+    targets = [
+        Taxon("FLYING.8472", False),
+        Taxon("FLYING.123", False),
+    ]
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    tree = pango_with_toy_alias.taxonomy_tree(input_taxa)
+    taxonomy_scheme = PhylogeneticTaxonomyScheme(tree)
+    agg = BasicPhylogeneticAggregator(
+        input_taxa, targets, taxonomy_scheme, unmapped_are_other=True
+    )
+
+    expected = {
+        "LIFE.1": "other",
+        "LIFE.1.2": "other",
+        "LIFE.123": "other",
+        "LIFE.7": "other",
+        "FLYING.8472.1": "FLYING.8472",
+        "FLYING.8472.1.2": "FLYING.8472",
+        "FLYING.8472.123": "FLYING.8472",
+        "FLYING.8472.7": "FLYING.8472",
+        "FLYING.123.1": "FLYING.123",
+        "FLYING.123.1.2": "FLYING.123",
+        "FLYING.123.123": "FLYING.123",
+        "FLYING.123.7": "FLYING.123",
+    }
+    assert agg.map() == expected
+
+
+def test_drop_self(pango_with_toy_alias):
+    targets = [
+        Taxon("FLYING.8472", False),
+        Taxon("FLYING.123", False),
+    ]
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    tree = pango_with_toy_alias.taxonomy_tree(input_taxa)
+    taxonomy_scheme = PhylogeneticTaxonomyScheme(tree)
+    agg = BasicPhylogeneticAggregator(
+        input_taxa, targets, taxonomy_scheme, unmapped_are_other=False
+    )
+
+    expected = {
+        "LIFE.1": "LIFE.1",
+        "LIFE.1.2": "LIFE.1.2",
+        "LIFE.123": "LIFE.123",
+        "LIFE.7": "LIFE.7",
+        "FLYING.8472.1": "FLYING.8472",
+        "FLYING.8472.1.2": "FLYING.8472",
+        "FLYING.8472.123": "FLYING.8472",
+        "FLYING.8472.7": "FLYING.8472",
+        "FLYING.123.1": "FLYING.123",
+        "FLYING.123.1.2": "FLYING.123",
+        "FLYING.123.123": "FLYING.123",
+        "FLYING.123.7": "FLYING.123",
+    }
     assert agg.map() == expected

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,0 +1,63 @@
+import pytest
+
+from cladecombiner import (
+    BasicPhylogeneticAggregator,
+    PhylogeneticTaxonomyScheme,
+    Taxon,
+    read_taxa,
+)
+
+
+@pytest.fixture
+def expected_one_agg():
+    expected = {}
+    expected["LIFE"] = ["LIFE.1", "LIFE.1.2", "LIFE.123", "LIFE.7"]
+    expected["FLYING.8472"] = [
+        "FLYING.8472.1",
+        "FLYING.8472.1.2",
+        "FLYING.8472.123",
+        "FLYING.8472.7",
+    ]
+    expected["FLYING.123"] = [
+        "FLYING.123.1",
+        "FLYING.123.1.2",
+        "FLYING.123.123",
+        "FLYING.123.7",
+    ]
+    return expected
+
+
+def test_no_drop_no_overlap(pango_with_toy_alias):
+    targets = [
+        Taxon("FLYING.8472", False),
+        Taxon("FLYING.123", False),
+        Taxon("PYTHONS.0.0.0", False),
+    ]
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    tree = pango_with_toy_alias.taxonomy_tree(input_taxa)
+    taxonomy_scheme = PhylogeneticTaxonomyScheme(tree)
+    agg = BasicPhylogeneticAggregator(input_taxa, targets, taxonomy_scheme)
+
+    expected = {
+        "LIFE.1": "PYTHONS.0.0.0",
+        "LIFE.1.2": "PYTHONS.0.0.0",
+        "LIFE.123": "PYTHONS.0.0.0",
+        "LIFE.7": "PYTHONS.0.0.0",
+        "FLYING.8472.1": "FLYING.8472",
+        "FLYING.8472.1.2": "FLYING.8472",
+        "FLYING.8472.123": "FLYING.8472",
+        "FLYING.8472.7": "FLYING.8472",
+        "FLYING.123.1": "FLYING.123",
+        "FLYING.123.1.2": "FLYING.123",
+        "FLYING.123.123": "FLYING.123",
+        "FLYING.123.7": "FLYING.123",
+    }
+    print("+++++++++++++++++++++++++++++++++++++++++")
+    print(agg.map())
+    print("+++++++++++++++++++++++++++++++++++++++++")
+    assert agg.map() == expected

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -2,6 +2,7 @@ import pytest
 
 from cladecombiner import (
     BasicPhylogeneticAggregator,
+    FixedAggregator,
     PhylogeneticTaxonomyScheme,
     Taxon,
     read_taxa,
@@ -25,6 +26,32 @@ def expected_one_agg():
         "FLYING.123.7",
     ]
     return expected
+
+
+def test_nocombiner(pango_with_toy_alias):
+    expected = {
+        "LIFE.1": "ARBITRARYTAXON.0",
+        "LIFE.1.2": "ARBITRARYTAXON.1",
+        "LIFE.123": "ARBITRARYTAXON.1",
+        "LIFE.7": "ARBITRARYTAXON.1",
+        "FLYING.8472.1": "ARBITRARYTAXON.0",
+        "FLYING.8472.1.2": "ARBITRARYTAXON.0",
+        "FLYING.8472.123": "ARBITRARYTAXON.0",
+        "FLYING.8472.7": "ARBITRARYTAXON.1",
+        "FLYING.123.1": "ARBITRARYTAXON.1",
+        "FLYING.123.1.2": "ARBITRARYTAXON.1",
+        "FLYING.123.123": "ARBITRARYTAXON.0",
+        "FLYING.123.7": "ARBITRARYTAXON.0",
+    }
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    agg = FixedAggregator([taxon.name for taxon in input_taxa], expected)
+
+    assert agg.map() == expected
 
 
 def test_no_drop_no_overlap(pango_with_toy_alias):

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -126,3 +126,73 @@ def test_drop_self(pango_with_toy_alias):
         "FLYING.123.7": "FLYING.123",
     }
     assert agg.map() == expected
+
+
+def test_overlap_sorted(pango_with_toy_alias):
+    targets = [
+        Taxon("PYTHONS.0.0.0", False),
+        Taxon("LIFE.1", False),
+        Taxon("FLYING.8472", False),
+        Taxon("FLYING.123", False),
+    ]
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    tree = pango_with_toy_alias.taxonomy_tree(input_taxa)
+    taxonomy_scheme = PhylogeneticTaxonomyScheme(tree)
+    agg = BasicPhylogeneticAggregator(input_taxa, targets, taxonomy_scheme)
+
+    expected = {
+        "LIFE.1": "LIFE.1",
+        "LIFE.1.2": "LIFE.1",
+        "LIFE.123": "PYTHONS.0.0.0",
+        "LIFE.7": "PYTHONS.0.0.0",
+        "FLYING.8472.1": "FLYING.8472",
+        "FLYING.8472.1.2": "FLYING.8472",
+        "FLYING.8472.123": "FLYING.8472",
+        "FLYING.8472.7": "FLYING.8472",
+        "FLYING.123.1": "FLYING.123",
+        "FLYING.123.1.2": "FLYING.123",
+        "FLYING.123.123": "FLYING.123",
+        "FLYING.123.7": "FLYING.123",
+    }
+    assert agg.map() == expected
+
+
+def test_overlap_unsorted(pango_with_toy_alias):
+    targets = [
+        Taxon("PYTHONS.0.0.0", False),
+        Taxon("LIFE.1", False),
+        Taxon("FLYING.8472", False),
+        Taxon("FLYING.123", False),
+    ]
+
+    input_taxa = read_taxa(
+        "tests/toy_lineages.txt",
+        is_tip=True,
+        nomenclature=pango_with_toy_alias,
+    )
+    tree = pango_with_toy_alias.taxonomy_tree(input_taxa)
+    taxonomy_scheme = PhylogeneticTaxonomyScheme(tree)
+    agg = BasicPhylogeneticAggregator(
+        input_taxa, targets, taxonomy_scheme, sort_clades=False, warn=False
+    )
+
+    expected = {
+        "LIFE.1": "PYTHONS.0.0.0",
+        "LIFE.1.2": "PYTHONS.0.0.0",
+        "LIFE.123": "PYTHONS.0.0.0",
+        "LIFE.7": "PYTHONS.0.0.0",
+        "FLYING.8472.1": "FLYING.8472",
+        "FLYING.8472.1.2": "FLYING.8472",
+        "FLYING.8472.123": "FLYING.8472",
+        "FLYING.8472.7": "FLYING.8472",
+        "FLYING.123.1": "FLYING.123",
+        "FLYING.123.1.2": "FLYING.123",
+        "FLYING.123.123": "FLYING.123",
+        "FLYING.123.7": "FLYING.123",
+    }
+    assert agg.map() == expected


### PR DESCRIPTION
This PR implements two very simple forms of lineage aggregation.

The `BasicPhylogeneticAggregator` takes in a set of input taxa to be aggregated, a set of aggregation target taxa to which we want to group the input taxa, and allows us to get the map we need to do this using the taxonomic relationships.

The `FixedAggregator` enables the user to specify exactly the mapping they want for all taxa. (Which is to say, functionally it does little other than checking the map for validity.) This would, for example, enable grouping a set of COVID lineages into the non-phylogenetic units "SGTF" and "non-SGTF."

## Implementation
The partially-abstract `Aggregator` class handles the details and bookkeeping of aggregation, while descendant classes (functional aggregators) provide the `next_agg_step()` method to determine what aggregation is actually done. It
- Maintains a stack of un-aggregated taxa which need to be aggregated
- Handles the construction of the map (via an intermediate map that records every step of the process)
- Provides basic checking that aggregation "steps" work and that the entire aggregation is valid (such that every input taxon is mapped to some output taxon). 

The actual aggregation is accomplished in `Aggregator.aggregate()` which loops until it depletes the stack, each time calling `next_agg_step()`, checking the proposed step, and finally implementing it. This structure means that subclasses must handle:
- Any necessary clean-up when aggregation is otherwise done. For example, when `BasicPhylogeneticAggregator` runs out of targets, `BasicPhylogeneticAggregator.next_agg_step()` will either map all remaining taxa to "other" or begin mapping remaining taxa to themselves.
- Any necessary operations in order for the aggregated taxa to have the correct data. This is not currently relevant but will be important for dynamic aggregation.

The setup gives `next_agg_step()` broad freedom in how it chooses the next step. It can map one taxon or many, according to any criterion it sees fit. The main restriction is that it is expected that it will _propose_ this step rather than take it. That is, it will not alter the stack or internal map state of its superclass. It should return an object of the (very small) dataclass `TaxonMapping` to specify
- What `{in : out}` mapping has been accomplished in this step
- Whether the `out` taxon (or taxa) is done (ineligible for further mapping) or not

## `BasicPhylogeneticAggregator` Example
```
import cladecombiner

pn = cladecombiner.PangoSc2Nomenclature()

lineages = [
    "BA.2",
    "BA.2.86",
    "XCU",
    "XDQ",
    "BQ.1.1.23",
    "JN.6",
    "JN.1.9.1",
    "JN.9",
    "KP.1.1",
    "FW.1.1.1",
    "BA.5.2.6"
]

pn.setup_alias_map()

tree = pn.taxonomy_tree([cladecombiner.Taxon(lin, True) for lin in lineages])

scheme = cladecombiner.PhylogeneticTaxonomyScheme(tree)

input_taxa = [taxon for taxon in scheme.taxon_to_node.keys() if taxon.tip]

target_taxa = [
    cladecombiner.Taxon("BA.2", False), 
    cladecombiner.Taxon("BA.2.86", False),
    cladecombiner.Taxon("BA.5", False),
]

agg = cladecombiner.BasicPhylogeneticAggregator(input_taxa, target_taxa, scheme)

agg.map()
```