### PR TITLE
Simplified aggregation scheme

### DIFF
--- a/cladecombiner/aggregator.py
+++ b/cladecombiner/aggregator.py
@@ -29,38 +29,14 @@ class TaxonMapping:
 
 
 class Aggregator(ABC):
-    """
-    A partially-abstract base class for aggregation.
-
-    Descendants need only implement next_agg_step() to create a usable aggregation object.
-    """
-
-    def __init__(
-        self,
-        input_taxa: Iterable[Taxon],
-    ):
-        """
-        Constructor for aggregation infrastructure shared by all subclasses.
-
-        Parameters
-        ----------
-        input_taxa : Iterable[Taxon]
-            The taxa we wish to aggregate.
-        """
-        self.input_taxa = list(input_taxa)
-        "The taxa we wish to aggregate."
-
-    def aggregate(self) -> TaxonMapping:
+    def aggregate(self, input_taxa: Iterable[Taxon]) -> TaxonMapping:
         pass
 
 
 class TrivialAggregator(Aggregator):
     """Map every taxon to itself; i.e., do nothing"""
 
-    def __init__(self, input_taxa: Iterable[Taxon]):
-        super().__init__(input_taxa)
-
-    def aggregate(self):
+    def aggregate(self, input_taxa: Iterable[Taxon]) -> TaxonMapping:
         tm = TaxonMapping(
             input_taxa=self.input_taxa, map={x: x for x in self.input_taxa}
         )
@@ -69,15 +45,12 @@ class TrivialAggregator(Aggregator):
 
 
 class FixedAggregator(Aggregator):
-    """
-    Aggregation via a user-provided dictionary.
-    """
+    """Aggregation via a user-provided dictionary"""
 
-    def __init__(self, input_taxa: Iterable[Taxon], map: dict[Taxon, Taxon]):
-        super().__init__(input_taxa)
+    def __init__(self, map: dict[Taxon, Taxon]):
         self.map = map
 
-    def aggregate(self) -> TaxonMapping:
+    def aggregate(self, input_taxa: Iterable[Taxon]) -> TaxonMapping:
         tm = TaxonMapping(self.input_taxa, self.map)
         tm.validate()
         return tm
@@ -90,7 +63,6 @@ class BasicPhylogeneticAggregator(Aggregator):
 
     def __init__(
         self,
-        input_taxa: Iterable[Taxon],
         target_taxa: Iterable[Taxon],
         taxonomy_scheme: PhylogeneticTaxonomyScheme,
         sort_clades: bool = True,
@@ -124,7 +96,6 @@ class BasicPhylogeneticAggregator(Aggregator):
             a target will be mapped to Taxon("other"). If False, any such taxa
             will be mapped to themselves.
         """
-        super().__init__(input_taxa)
 
         if sort_clades:
             self.target_taxa = [
@@ -142,63 +113,44 @@ class BasicPhylogeneticAggregator(Aggregator):
             self.target_taxa = list(target_taxa)
 
         # So .pop() executes these in the expected order
-        self.targets.reverse()
+        self.target_taxa.reverse()
         self.taxonomy_scheme = taxonomy_scheme
-        self.agg_other = unmapped_are_other
+        self.unmapped_are_other = unmapped_are_other
         self.warn = warn
 
-    def aggregate(self):
-        # initialize the aggregator state: initially, no taxa are "done"
-        # (i.e., terminally mapped)
-        done_taxa = []
-        stack = [taxon for taxon in self.input_taxa if taxon not in done_taxa]
-        # I'm not surehow to initialize the mapping
-        step = None
-        while self.stack:
-            # confusingly, the "step" is actually a map. I think it would be
-            # easier if .next_step() took in the current map and gave an updated
-            # one
-            step = self.next_step(step)
-            # then we want to check that that updated mapping looks good
-            self.validate_step(step)
-            # not sure we need this, in that paradigm
-            self.resolve_step(step)
+    def aggregate(self, input_taxa: Iterable[Taxon]) -> TaxonMapping:
+        # initialize the state; not sure what this should be
+        mapping = None
+        # stack are the incomplete taxa
+        stack = None
 
-        # the step is actually a TaxonMapping, which should now be complete
-        step.validate()
+        # iterate
+        while stack:
+            # update the mapping
+            mapping = self.step(mapping)
+            # validate the mapping
+            self.validate_step(mapping)
 
-        return step
+        # validate the final mapping
+        self.validate_complete()
+
+        # the mapping should be complete
+        mapping.validate()
+
+        return mapping
 
     @staticmethod
     def validate_step(mapping: TaxonMapping):
-        # I'm not sure if, at every step here, the mapping is "complete" in the
-        # sense that we could validly stop the aggregation at that point. So we
-        # might need some different kind of validation here.
-        mapping.validate()
+        # check for unknown output taxa
+        raise NotImplementedError
 
-        unknown_taxa = [
-            taxon for taxon in mapping.done.keys() if not self.taxon_is_valid(taxon)
-        ]
-        if len(unknown_taxa) > 0:
-            raise RuntimeError(
-                f"Aggregation step resulted in the following taxa unknown to the provided taxonomy scheme: {unknown_taxa}"
-            )
+    @staticmethod
+    def validate_complete(mapping: TaxonMapping):
+        # check that all the input taxa were used?
+        raise NotImplementedError
 
-        # I'm not sure if these belong together!
-        if self.warn:
-            used_targets = set(self.map().values())
-            unused_targets = [
-                target.name
-                for target in self._input_targets
-                if target.name not in used_targets
-            ]
-            if len(unused_targets) > 0:
-                warn(
-                    f"The aggregation does not make use of the following input targets: {unused_targets}."
-                )
-
-    def next_agg_step(self) -> TaxonMapping:
-        if len(self.targets) > 0:
+    def step(self, incomplete_targets, mapping: TaxonMapping) -> TaxonMapping:
+        if len(self.target_taxa) > 0:
             target = self.targets.pop()
             children = self.taxonomy_scheme.descendants(target, True)
             taxa = [taxon for taxon in self.stack if taxon in children]
@@ -215,9 +167,28 @@ class BasicPhylogeneticAggregator(Aggregator):
         done = {target: True}
         return TaxonMapping(map, done)
 
-    def taxon_is_valid(self, taxon: Taxon) -> bool:
-        if self.taxonomy_scheme.is_valid_taxon(taxon):
-            return True
-        elif self.agg_other and taxon == Taxon("other", False):
-            return True
-        return False
+
+class SerialAggregator(Aggregator):
+    def __init__(self, aggregators: Iterable[Aggregator]):
+        self.aggregators = aggregators
+
+    def aggregate(self, input_taxa: Iterable[Taxon]) -> TaxonMapping:
+        # initialize the input taxa
+        input_taxa = list(input_taxa)
+        composite_mapping = {taxon: None for taxon in input_taxa}
+
+        for aggregator in self.aggregators:
+            # get the next mapping
+            mapping = aggregator.aggregate(input_taxa)
+            # input for the next step are targets from this step
+            input_taxa = list(mapping.map.values())
+            # update the composite mapping: say the composite map has A -> B
+            # and this next mapping has B -> C, so we update the composite map
+            # to be A -> C
+            composite_mapping = TaxonMapping(
+                {key: mapping.map[value] for key, value in composite_mapping.items()}
+            )
+
+        composite_mapping.validate()
+
+        return composite_mapping


### PR DESCRIPTION
- `TaxonMapping` knows the input data, so it can validate if it is a potentially finished mapping.
  - I think the current implementation is clunky. I would make it so that TaxonMapping inherits from dict, so we don't have the awkward `mapping.map.keys()`
- `Aggregator` takes all the information *aside from the input taxa* needed to do a mapping. It's like a partial function!
- `Aggregator.aggregate()` takes the input taxa and outputs a `TaxonMapping`
- Beyond that, it's up to individual aggregators to decide what to do.
  - Very simple aggregators just do it and don't need to maintain any state or have steps
  - Iterative aggregators have some kind of transient state, and steps, and some step-by-step validation
- The APIs for `Aggregator` and `Aggregator.aggregate()` allow for the serial aggregator, which takes in a list of Aggregators and then can apply each one in serial