### PR TITLE
Make Pango SC2 an instance

### DIFF
--- a/cladecombiner/__init__.py
+++ b/cladecombiner/__init__.py
@@ -3,7 +3,8 @@ from .aggregator import (
     BasicPhylogeneticAggregator as BasicPhylogeneticAggregator,
 )
 from .aggregator import SerialAggregator as SerialAggregator
-from .nomenclature import PangoSc2Nomenclature as PangoSc2Nomenclature
+from .nomenclature import PangoNomenclature as PangoNomenclature
+from .nomenclature import pango_sc2_nomenclature as pango_sc2_nomenclature
 from .taxon import Taxon as Taxon
 from .taxon_utils import read_taxa as read_taxa
 from .taxon_utils import sort_taxa as sort_taxa

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytest
 
 import cladecombiner
@@ -26,9 +28,10 @@ def pango_with_toy_alias():
                                                                                                   |
                                                                                                   \---FLYING.8472---FLYING.8472.8472---FLYING.8472.8472.8472=CIRCUS
     """
-    pango = cladecombiner.PangoSc2Nomenclature()
+    pango = copy.deepcopy(cladecombiner.pango_sc2_nomenclature)
     pango.special = ["MONTY"]
-    pango.setup_alias_map(fp="tests/toy_alias.json")
+    pango.fp_alias_json = "tests/toy_alias.json"
+    pango.setup_alias_map()
     return pango
 
 
@@ -79,9 +82,10 @@ def pango_with_recomb_alias():
                                                                        \-----C.4-----/
     """
 
-    pango = cladecombiner.PangoSc2Nomenclature()
+    pango = copy.deepcopy(cladecombiner.pango_sc2_nomenclature)
     pango.special = ["A"]
-    pango.setup_alias_map(fp="tests/recomb_alias.json")
+    pango.fp_alias_json = "tests/recomb_alias.json"
+    pango.setup_alias_map()
     return pango
 
 
@@ -90,9 +94,10 @@ def tax_tree():
     """
     A taxonomy tree constructed for taxa from the above recombinant alias history.
     """
-    pango = cladecombiner.PangoSc2Nomenclature()
+    pango = copy.deepcopy(cladecombiner.pango_sc2_nomenclature)
     pango.special = ["A"]
-    pango.setup_alias_map(fp="tests/recomb_alias.json")
+    pango.fp_alias_json = "tests/recomb_alias.json"
+    pango.setup_alias_map()
 
     names = [
         "A",
@@ -126,9 +131,10 @@ def pango_phylo_taxonomy():
     """
     A taxonomy scheme using taxonomy tree for taxa from the above recombinant alias history.
     """
-    pango = cladecombiner.PangoSc2Nomenclature()
+    pango = copy.deepcopy(cladecombiner.pango_sc2_nomenclature)
     pango.special = ["A"]
-    pango.setup_alias_map(fp="tests/recomb_alias.json")
+    pango.fp_alias_json = "tests/recomb_alias.json"
+    pango.setup_alias_map()
 
     names = [
         "A",

--- a/tests/test_pango.py
+++ b/tests/test_pango.py
@@ -1,10 +1,9 @@
 import pytest
 
-from cladecombiner import PangoSc2Nomenclature
+from cladecombiner import pango_sc2_nomenclature as pn
 
 
 def test_split():
-    pn = PangoSc2Nomenclature()
     assert pn.split("CIRCUS.1001.1002.1003") == [
         "CIRCUS",
         "1001",
@@ -14,7 +13,6 @@ def test_split():
 
 
 def test_join():
-    pn = PangoSc2Nomenclature()
     assert (
         pn.join(["CIRCUS", "1001", "1002", "1003"]) == "CIRCUS.1001.1002.1003"
     )
@@ -88,7 +86,6 @@ def test_validate(pango_with_toy_alias):
 
 
 def test_longer_name_nolist():
-    pn = PangoSc2Nomenclature()
     with pytest.raises(RuntimeError):
         pn.longer_name("CIRCUS.1001.1002.1003")
 


### PR DESCRIPTION
Resolves #6

This required some refactoring of the Nomenclature hierarchy so as to make `PangoNomenclature` an initializable object while preserving the ability to defer to local aliasing.