### PR TITLE
CI: mkdocs build

### DIFF
--- a/.github/actions/mkdocs_build/action.yaml
+++ b/.github/actions/mkdocs_build/action.yaml
@@ -1,0 +1,20 @@
+name: mkdocs_build
+description: build mkdocs
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+    - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      shell: bash
+    - uses: actions/cache@v4
+      with:
+        key: mkdocs-material-${{ env.cache_id }}
+        path: .cache
+        restore-keys: |
+          mkdocs-material-
+    - run: pip install mkdocs-material mkdocstrings "mkdocstrings[python]" mdx-truly-sane-lists
+      shell: bash
+    - run: mkdocs build
+      shell: bash

--- a/.github/workflows/mkdocs_build.yaml
+++ b/.github/workflows/mkdocs_build.yaml
@@ -1,0 +1,11 @@
+name: mkdocs_build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/mkdocs_build


### PR DESCRIPTION
This will build mkdocs on PR, as a check that everything is working.

Something like https://github.com/CDCgov/pygriddler/blob/main/.github/workflows/mkdocs_deploy.yaml will deploy too, although I think that file was auto-configured by mkdocs?